### PR TITLE
Fix config of receiver specific queue 

### DIFF
--- a/src/main/java/org/example/ui/pages/ParametersPage.java
+++ b/src/main/java/org/example/ui/pages/ParametersPage.java
@@ -874,8 +874,8 @@ public class ParametersPage extends JPanel {
                 String stringParameterPid;
                 if (stringParameterIdMap.startsWith(STRING_PARAMETER_ID_RECEIVER_SPECIFIC_QUEUE)) {
                     String receiverName = stringParameterIdMap.replace(STRING_PARAMETER_ID_RECEIVER_SPECIFIC_QUEUE, "");
-                    stringParameterId = STRING_PARAMETER_ID_RECEIVER_SPECIFIC_QUEUE;
-                    stringParameterPid = receiverName;
+                    stringParameterId = STRING_PARAMETER_ID_RECEIVER_SPECIFIC_QUEUE + receiverName;
+                    stringParameterPid = pid;
                 } else {
                     stringParameterId = stringParameterIdMap;
                     stringParameterPid = pid;


### PR DESCRIPTION
This is a small fix for writing the receiver specific queue on scenario level to the PDir (should be written to the PID of the scenario and not the receiver.)

This is documented here: https://help.sap.com/docs/migration-guide-po/migration-guide-for-sap-process-orchestration/message-processing-behavior?locale=en-US#receiver-specific-outbound-queue

As a consequence, setting the default queue on the receiver is something we should add to the tool. It must not be on the scenario parameters page. Suggestion is to put it on the Landscape stages page, for example right above the Radio buttons below the dropdown of the receiver system.